### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,75 +1,75 @@
 ---
-sudo: required
 language: python
+
+sudo: required
 
 services:
   - docker
 
-python: "2.7"
-
-cache: pip
-
-virtualenv:
-  system_site_packages: false
-
 install:
-- pip install --upgrade setuptools
-- if [[ -d $ROLE/molecule ]]; then pip install ome-ansible-molecule/; else
-  pip install ome-ansible-molecule-dependencies; fi
+ - pip install --upgrade setuptools
+ - pip install ome-ansible-molecule/
 
 script:
-# Some roles can't be properly tested in Docker
-# These should provide an alternative configuration just for testing syntax
-- cd $ROLE
-- if [ -f molecule-docker.yml ]; then mv molecule-docker.yml molecule.yml; fi
-- ../scripts/test.sh
+ - cd $ROLE && ../scripts/test.sh
 
 env:
- - ROLE=ansible-role-analysis-tools
- - ROLE=ansible-role-anonymous-ftp
- - ROLE=ansible-role-basedeps
- - ROLE=ansible-role-cadvisor
- - ROLE=ansible-role-cli-utils
- - ROLE=ansible-role-deploy-archive
- - ROLE=ansible-role-docker-tools
- - ROLE=ansible-role-fluentd
- - ROLE=ansible-role-hosts-populate
- - ROLE=ansible-role-ice
- - ROLE=ansible-role-iptables-raw
- - ROLE=ansible-role-java
- - ROLE=ansible-role-local-accounts
- - ROLE=ansible-role-logrotate
- - ROLE=ansible-role-lvm-partition
- - ROLE=ansible-role-mysql-backup
- - ROLE=ansible-role-network-cloud-interfaces
- - ROLE=ansible-role-network
- - ROLE=ansible-role-nfs-mount
- - ROLE=ansible-role-nfs-share
- - ROLE=ansible-role-nginx-proxy
- - ROLE=ansible-role-nginx
- - ROLE=ansible-role-omego
- - ROLE=ansible-role-omero-common
- - ROLE=ansible-role-omero-prometheus-exporter
- - ROLE=ansible-role-omero-python-deps
- - ROLE=ansible-role-omero-server
- - ROLE=ansible-role-omero-user
- - ROLE=ansible-role-omero-web-django-prometheus
- - ROLE=ansible-role-omero-web
- - ROLE=ansible-role-openstack-volume-storage
- - ROLE=ansible-role-postgresql
- - ROLE=ansible-role-postgresql-backup
- - ROLE=ansible-role-prometheus-jmx
- - ROLE=ansible-role-prometheus-node
- - ROLE=ansible-role-prometheus-postgres
- - ROLE=ansible-role-python-pydata
- - ROLE=ansible-role-reboot-server
- - ROLE=ansible-role-redis
- - ROLE=ansible-role-rsync-server
- - ROLE=ansible-role-samba-client
- - ROLE=ansible-role-selinux-utils
- - ROLE=ansible-role-ssl-certificate
- - ROLE=ansible-role-storage-volume-initialise
- - ROLE=ansible-role-sudoers
- - ROLE=ansible-role-system-monitor-agent
- - ROLE=ansible-role-upgrade-distpackages
- - ROLE=ansible-role-versioncontrol-utils
+ - ROLE=ansible-role-analysis-tools SCENARIO=
+ - ROLE=ansible-role-anonymous-ftp SCENARIO=
+ - ROLE=ansible-role-basedeps SCENARIO=
+ - ROLE=ansible-role-cadvisor SCENARIO=
+ - ROLE=ansible-role-cli-utils SCENARIO=
+ - ROLE=ansible-role-deploy-archive SCENARIO=
+ - ROLE=ansible-role-docker-tools SCENARIO=
+ - ROLE=ansible-role-fluentd SCENARIO=
+ - ROLE=ansible-role-hosts-populate SCENARIO=
+ - ROLE=ansible-role-ice SCENARIO=ice36all
+ - ROLE=ansible-role-ice SCENARIO=ice36minimal
+ - ROLE=ansible-role-ice SCENARIO=ice36-ubuntu1804
+ - ROLE=ansible-role-iptables-raw SCENARIO=
+ - ROLE=ansible-role-java SCENARIO=centos
+ - ROLE=ansible-role-java SCENARIO=ubuntu
+ - ROLE=ansible-role-local-accounts SCENARIO=
+ - ROLE=ansible-role-logrotate SCENARIO=
+ - ROLE=ansible-role-lvm-partition SCENARIO=
+ - ROLE=ansible-role-mysql-backup SCENARIO=
+ - ROLE=ansible-role-network-cloud-interfaces SCENARIO=
+ - ROLE=ansible-role-network SCENARIO=
+ - ROLE=ansible-role-nfs-mount SCENARIO=
+ - ROLE=ansible-role-nfs-share SCENARIO=
+ - ROLE=ansible-role-nginx-proxy SCENARIO=
+ - ROLE=ansible-role-nginx SCENARIO=centos7
+ - ROLE=ansible-role-nginx SCENARIO=ubuntu1804
+ - ROLE=ansible-role-omego SCENARIO=
+ - ROLE=ansible-role-omero-common SCENARIO=
+ - ROLE=ansible-role-omero-prometheus-exporter SCENARIO=
+ - ROLE=ansible-role-omero-python-deps SCENARIO=
+ - ROLE=ansible-role-omero-server SCENARIO=newdep
+ - ROLE=ansible-role-omero-server SCENARIO=python3
+ - ROLE=ansible-role-omero-server SCENARIO=upgrade-py2py3
+ - ROLE=ansible-role-omero-server SCENARIO=upgradetovenv
+ - ROLE=ansible-role-omero-user SCENARIO=
+ - ROLE=ansible-role-omero-web-django-prometheus SCENARIO=
+ - ROLE=ansible-role-omero-web SCENARIO=active
+ - ROLE=ansible-role-omero-web SCENARIO=inactive
+ - ROLE=ansible-role-omero-web SCENARIO=active-py3-centos7
+ - ROLE=ansible-role-omero-web SCENARIO=active-py3-ubuntu1804
+ - ROLE=ansible-role-omero-web SCENARIO=py2-py3-upgrade-centos7
+ - ROLE=ansible-role-openstack-volume-storage SCENARIO=
+ - ROLE=ansible-role-postgresql SCENARIO=
+ - ROLE=ansible-role-postgresql-backup SCENARIO=
+ - ROLE=ansible-role-prometheus-jmx SCENARIO=
+ - ROLE=ansible-role-prometheus-node SCENARIO=
+ - ROLE=ansible-role-prometheus-postgres SCENARIO=
+ - ROLE=ansible-role-python-pydata SCENARIO=
+ - ROLE=ansible-role-reboot-server SCENARIO=
+ - ROLE=ansible-role-redis SCENARIO=
+ - ROLE=ansible-role-rsync-server SCENARIO=
+ - ROLE=ansible-role-samba-client SCENARIO=
+ - ROLE=ansible-role-selinux-utils SCENARIO=
+ - ROLE=ansible-role-ssl-certificate SCENARIO=
+ - ROLE=ansible-role-storage-volume-initialise SCENARIO=
+ - ROLE=ansible-role-sudoers SCENARIO=
+ - ROLE=ansible-role-system-monitor-agent SCENARIO=
+ - ROLE=ansible-role-upgrade-distpackages SCENARIO=
+ - ROLE=ansible-role-versioncontrol-utils SCENARIO=

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 
-if [[ -f molecule.yml ]]; then
-    molecule test
-elif [[ -d molecule ]]; then
-    if molecule list -s travis; then
-        molecule test -s travis
-    else
+if [[ -d molecule ]]; then
+    if [[ -z $SCENARIO ]]; then
         molecule test --all
+    else
+        molecule test -s $SCENARIO
     fi
 else
     ### From .travis.yml of the non-molecule roles


### PR DESCRIPTION
- remove handling of Molecule 1.x in test.sh
- split multi-scenario tests into separate builds

Closes #13 

I am not fully satisfied with the addition of the `SCENARIO` handling as it is not really scalable i.e. if a scenario gets added to a role, this is not propagated at this level. However, as it stands, complex roles with multiple scenarios like `ansible-role-omero-server` systematically hit the 50min timeout.